### PR TITLE
Fix broken markdown link

### DIFF
--- a/.github/steps/1-initialize-javascript-project.md
+++ b/.github/steps/1-initialize-javascript-project.md
@@ -69,7 +69,7 @@ Once you have the necessary tools installed locally, follow these steps to begin
    ```shell
    npm init -y
    ```
-8. Install the **request**, **request-promise** and **@actions/core** dependencies using `npm` from the [GitHub ToolKit] (https://github.com/actions/toolkit):
+8. Install the **request**, **request-promise** and **@actions/core** dependencies using `npm` from the [GitHub ToolKit](https://github.com/actions/toolkit):
    ```shell
    npm install --save request request-promise @actions/core
    ```


### PR DESCRIPTION
### Summary

In one of the steps a Markdown link (`[text](//example.com)`) was broken by a space between the `[]` and `()`.

### Changes

This removes the space so that the link renders as expected.

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
