### PR TITLE
Change trigger for step 0 to push

### DIFF
--- a/.github/workflows/0-welcome.yml
+++ b/.github/workflows/0-welcome.yml
@@ -9,7 +9,9 @@ name: Step 0, Welcome
 # The conditions within the on_start job are to ensure it is only fully executed once.
 # Reference: https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows
 on:
-  create:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->

The course isn't kicking off step 1 because of the use of the `create` trigger. Changing to `push` in `main`. 

### Changes

This pull request changes the trigger for step 0 to `push` in the `.github/workflows/0-welcome.yml` file.

Closes https://github.com/skills/write-javascript-actions/issues/44

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
