### PR TITLE
remove .git extension

### DIFF
--- a/.github/steps/1-initialize-javascript-project.md
+++ b/.github/steps/1-initialize-javascript-project.md
@@ -47,7 +47,7 @@ Once you have the necessary tools installed locally, follow these steps to begin
 1. Open the **Terminal** (Mac and Linux) or **Command Prompt** (Windows) on your local machine
 2. Clone your Skills repo to your local machine:
    ```shell
-   git clone <this repository URL>.git
+   git clone <this repository URL>
    ```
 3. Navigate to the folder you just cloned:
    ```shell


### PR DESCRIPTION
### Summary

Very minor edit and admittedly pedantic, but the `.git` extension is really only needed for a "bare git repo" - explained pretty well here: https://stackoverflow.com/a/1734421

When cloning a repo at the top-level from GitHub, it's redundant and potentially misleading to include the `.git` extension

### Changes

This is just a docs change, so don't anticipate any impact on automation

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
