### PR TITLE
Add node_modules to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Node.js dependencies #
+########################
+node_modules/


### PR DESCRIPTION
### Summary
This PR updates the .gitignore file to exclude node_modules. This prevents unnecessary large files from being committed, keeping the repository clean and efficient.


### Changes
Added node_modules/ to .gitignore under the "Packages" section.

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

Closes:

### Task list

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
